### PR TITLE
Add custom renderText and onSend

### DIFF
--- a/GiftedMessenger.js
+++ b/GiftedMessenger.js
@@ -67,6 +67,8 @@ var GiftedMessenger = React.createClass({
     initialMessages: React.PropTypes.array,
     messages: React.PropTypes.array,
     handleSend: React.PropTypes.func,
+    onCustomSend: React.PropTypes.func,
+    renderCustomText: React.PropTypes.func,
     maxHeight: React.PropTypes.number,
     senderName: React.PropTypes.string,
     senderImage: React.PropTypes.object,
@@ -266,6 +268,9 @@ var GiftedMessenger = React.createClass({
       );
     }
     */
+    if (this.props.renderCustomText) {
+      return this.props.renderCustomText(rowData, rowID);
+    }
     return (
       <Text
         style={[this.styles.text, (rowData.position === 'left' ? this.styles.textLeft : this.styles.textRight)]}
@@ -351,10 +356,14 @@ var GiftedMessenger = React.createClass({
       position: 'right',
       date: new Date(),
     };
-    var rowID = this.appendMessage(message);
-    this.props.handleSend(message, rowID);
-    this.onChangeText('');
-    this.scrollResponder.scrollTo(0);
+    if (this.props.onCustomSend) {
+      this.props.onCustomSend(message);
+    } else {
+      var rowID = this.appendMessage(message);
+      this.props.handleSend(message, rowID);
+      this.onChangeText('');
+      this.scrollResponder.scrollTo(0);
+    }
   },
   
   postLoadEarlierMessages(messages = [], allLoaded = false) {


### PR DESCRIPTION
Custom renderText and onSend are very useful for me.
```javascript
var HTMLView = require('react-native-htmlview');
var Chatroom = React.createClass({
  ...
  renderCustomText(rowData, rowID) {
    return <HTMLView
      value={rowData.text}
      onLinkPress={this._handleUrlPress}
      stylesheet={{
        a: {
          color: (rowData.position === 'left' ? 'blue': '#fff'),
          textDecorationLine: 'underline',
        },
      }}
    />
  },
  onCustomSend(message) {
    this.showProgressHUD();
    this.sendMessageAPI(message.text).then(response => {
      this.dismissProgressHUD();
      this.refs.GiftedMessenger.appendMessage(message);
      this.refs.GiftedMessenger.onChangeText('');
    }).catch(error => {
      this.dismissProgressHUD();
      AlertIOS.alert(error.message);
    });
  },
  render() {
    return (
      <GiftedMessenger
        ref='GiftedMessenger'
        onCustomSend={this.onCustomSend}
        renderCustomText={this.renderCustomText}
      />
    );
  }
});
```