### PR TITLE
Make changing sendButton color possible w/o breaking the disabled color

### DIFF
--- a/GiftedMessenger.js
+++ b/GiftedMessenger.js
@@ -499,6 +499,7 @@ var GiftedMessenger = React.createClass({
           />
           <Button
             style={this.styles.sendButton}
+            styleDisabled={this.styles.sendButtonDisabled}
             onPress={this.onSend}
             disabled={this.state.disabled}
           >


### PR DESCRIPTION
Before if sendButton color was changed, the disabled sendButton color changed also as a side effect. This makes it possible to customize styles of both sendButton and sendButtonDisabled.