### PR TITLE
Minor usability fixes to the UX

### DIFF
--- a/GiftedMessenger.js
+++ b/GiftedMessenger.js
@@ -494,6 +494,7 @@ var GiftedMessenger = React.createClass({
             autoFocus={this.props.autoFocus}
             returnKeyType={this.props.submitOnReturn ? 'send' : 'default'}
             onSubmitEditing={this.props.submitOnReturn ? this.onSend : null}
+            enablesReturnKeyAutomatically={true}
 
             blurOnSubmit={false}
           />

--- a/GiftedMessenger.js
+++ b/GiftedMessenger.js
@@ -282,7 +282,7 @@ var GiftedMessenger = React.createClass({
     if (this.props.onCustomSend) {
       this.props.onCustomSend(message);
     } else {
-      var rowID = this.appendMessage(message);
+      var rowID = this.appendMessage(message, true);
       this.props.handleSend(message, rowID);
       this.onChangeText('');
     }

--- a/Message.js
+++ b/Message.js
@@ -76,7 +76,6 @@ export default class Message extends React.Component {
             <TouchableHighlight
               underlayColor='transparent'
               onPress={() => onImagePress(rowData, rowID)}
-              style={styles.imagePosition}
             >
               <Image source={rowData.image} style={[styles.imagePosition, styles.image, (rowData.position === 'left' ? styles.imageLeft : styles.imageRight)]}/>
             </TouchableHighlight>


### PR DESCRIPTION
- Enable sending message with return key (this should be default behavior)
- Scroll to bottom after send (the functionality is there, it's just not used atm.)
- Remove styles.imagePosition from avatar pic's TouchableHighlight (currently styles.imagePosition is used both for the Image element **and** the TouchableHighlight, which is probably a mistake)