### PR TITLE
Add prop that causes names to show inside a bubble, rather than above it

### DIFF
--- a/Bubble.js
+++ b/Bubble.js
@@ -65,6 +65,7 @@ export default class Bubble extends React.Component {
         (this.props.position === 'left' ? styles.bubbleLeft : styles.bubbleRight),
         (this.props.status === 'ErrorButton' ? styles.bubbleError : null),
         flexStyle]}>
+        {this.props.name}
         {this.renderText(this.props.text, this.props.position)}
       </View>
     )
@@ -75,5 +76,6 @@ Bubble.propTypes = {
   position: React.PropTypes.oneOf(['left','right']),
   status: React.PropTypes.string,
   text: React.PropTypes.string,
-  renderCustomText: React.PropTypes.func
+  renderCustomText: React.PropTypes.func,
+  name: React.PropTypes.element
 }

--- a/GiftedMessenger.js
+++ b/GiftedMessenger.js
@@ -29,6 +29,7 @@ var GiftedMessenger = React.createClass({
   getDefaultProps() {
     return {
       displayNames: true,
+      displayNamesInsideBubble: false,
       placeholder: 'Type a message...',
       styles: {},
       autoFocus: true,
@@ -58,6 +59,7 @@ var GiftedMessenger = React.createClass({
 
   propTypes: {
     displayNames: React.PropTypes.bool,
+    displayNamesInsideBubble: React.PropTypes.bool,
     placeholder: React.PropTypes.string,
     styles: React.PropTypes.object,
     autoFocus: React.PropTypes.bool,
@@ -186,6 +188,7 @@ var GiftedMessenger = React.createClass({
           rowID={rowID}
           onErrorButtonPress={this.props.onErrorButtonPress}
           displayNames={this.props.displayNames}
+          displayNamesInsideBubble={this.props.displayNamesInsideBubble}
           diffMessage={diffMessage}
           position={rowData.position}
           forceRenderImage={this.props.forceRenderImage}

--- a/Message.js
+++ b/Message.js
@@ -13,6 +13,10 @@ var styles = StyleSheet.create({
     marginLeft: 55,
     marginBottom: 5,
   },
+  nameInsideBubble: {
+    color: '#666666',
+    marginLeft: 0
+  },
   imagePosition: {
     height: 30,
     width: 30,
@@ -46,7 +50,7 @@ export default class Message extends React.Component {
   constructor(props) {
     super(props);
   }
-  
+
   componentWillMount() {
     Object.assign(styles, this.props.styles);
   }
@@ -55,7 +59,9 @@ export default class Message extends React.Component {
     if (displayNames === true) {
       if (diffMessage === null || name !== diffMessage.name) {
         return (
-          <Text style={[styles.name]}>
+          <Text style={[styles.name,
+            this.props.displayNamesInsideBubble ? styles.nameInsideBubble : null
+            ]}>
             {name}
           </Text>
         );
@@ -149,7 +155,7 @@ export default class Message extends React.Component {
 
     var messageView = (
       <View>
-        {position === 'left' ? this.renderName(rowData.name, displayNames, diffMessage) : null}
+        {position === 'left' && !this.props.displayNamesInsideBubble ? this.renderName(rowData.name, displayNames, diffMessage) : null}
         <View style={[styles.rowContainer, {
             justifyContent: position==='left'?"flex-start":"flex-end"
           }]}>
@@ -159,13 +165,14 @@ export default class Message extends React.Component {
             {...rowData}
             renderCustomText={this.props.renderCustomText}
             styles={styles}
+            name={position === 'left' && this.props.displayNamesInsideBubble ? this.renderName(rowData.name, displayNames, diffMessage) : null}
             />
           {rowData.position === 'right' ? this.renderImage(rowData, rowID, diffMessage, forceRenderImage, onImagePress) : null}
         </View>
         {rowData.position === 'right' ? this.renderStatus(rowData.status) : null}
       </View>
     );
-    
+
     if (typeof onMessageLongPress === 'function') {
       return (
         <TouchableHighlight

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ See [GiftedMessengerExample/GiftedMessengerExample.js](https://raw.githubusercon
 | ----------------------------- | -------- | -------------------------------------------------------------------------- | -------- | -------------------------------- |
 | messages                      | Array    | List of messages to display                                                | Both     | []                               |
 | displayNames                  | Boolean  | Display or not the name of the interlocutor(s)                             | Both     | true                             |
+| displayNamesInsideBubble      | Boolean  | Display the name of the interlocutor(s) inside the bubble                  | Both     | false                             |
 | placeholder                   | String   | TextInput placeholder                                                      | Both     | 'Type a message...'              |
 | styles                        | Function | Styles of children components - See GiftedMessenger.js/componentWillMount  | Both     | {}                               |
 | autoFocus                     | Boolean  | TextInput auto focus                                                       | Both     | true                             |


### PR DESCRIPTION
Many apps want to show names inside the text bubble, rather than above it. I've added a prop `displayNamesInsideBubble`, to enable this (by setting it to true). It only does something if `displayNames` is true as well. 

Ideally both of these props would be combined in a single prop `displayNames`, which could have values such as 'no', 'inside-bubble' and 'above-bubble', but since that might break previous implementations I have chosen to make it a separate prop. 