### PR TITLE
Fix keyboardDismissMode and add keyboardShouldPersistsTaps

### DIFF
--- a/GiftedMessenger.js
+++ b/GiftedMessenger.js
@@ -51,6 +51,8 @@ var GiftedMessenger = React.createClass({
       onImagePress: null,
       onMessageLongPress: null,
       hideTextInput: false,
+      keyboardDismissMode: 'interactive',
+      keyboardShouldPersistTaps: true,
       submitOnReturn: false,
       forceRenderImage: false,
       onChangeText: (text) => {},
@@ -84,6 +86,8 @@ var GiftedMessenger = React.createClass({
     onImagePress: React.PropTypes.func,
     onMessageLongPress: React.PropTypes.func,
     hideTextInput: React.PropTypes.bool,
+    keyboardDismissMode: React.PropTypes.string,
+    keyboardShouldPersistTaps: React.PropTypes.bool,
     forceRenderImage: React.PropTypes.bool,
     onChangeText: React.PropTypes.func,
   },
@@ -468,13 +472,9 @@ var GiftedMessenger = React.createClass({
           onKeyboardWillHide={this.onKeyboardWillHide}
           onKeyboardDidHide={this.onKeyboardDidHide}
 
-          /*
-            keyboardShouldPersistTaps={false} // @issue keyboardShouldPersistTaps={false} + textInput focused = 2 taps are needed to trigger the ParsedText links
-            keyboardDismissMode='interactive'
-          */
 
-          keyboardShouldPersistTaps={true}
-          keyboardDismissMode='interactive'
+          keyboardShouldPersistTaps={this.props.keyboardShouldPersistTaps} // @issue keyboardShouldPersistTaps={false} + textInput focused = 2 taps are needed to trigger the ParsedText links
+          keyboardDismissMode={this.props.keyboardDismissMode}
 
 
           initialListSize={10}

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ var GiftedMessengerExample = React.createClass({
   },
   handleReceive() {
     this._GiftedMessenger.appendMessage({
-      text: 'Received message', 
-      name: 'Friend', 
-      image: {uri: 'https://facebook.github.io/react/img/logo_og.png'}, 
-      position: 'left', 
+      text: 'Received message',
+      name: 'Friend',
+      image: {uri: 'https://facebook.github.io/react/img/logo_og.png'},
+      position: 'left',
       date: new Date(),
     });
   },
@@ -53,7 +53,7 @@ var GiftedMessengerExample = React.createClass({
         messages={this.getMessages()}
         handleSend={this.handleSend}
         maxHeight={Dimensions.get('window').height - 64} // 64 for the navBar
-        
+
         styles={{
           bubbleLeft: {
             backgroundColor: '#e6e6eb',
@@ -106,6 +106,7 @@ See [GiftedMessengerExample/GiftedMessengerExample.js](https://raw.githubusercon
 | handlePhonePress              | Function | Called when a parsed phone number is pressed                               | iOS      | (phone) => {}                    |
 | handleEmailPress              | Function | Called when a parsed email is pressed                                      | iOS      | (email) => {}                    |
 | hideTextInput                 | Boolean  | Hide or not the text input                                                 | Both     | false                            |
+| keyboardShouldPersistTaps     | Boolean  | When false, tapping the scrollview dismisses the keyboard.                 | Both     | true                             |
 | keyboardDismissMode           | String   | Method to dismiss the keyboard when dragging (none, interactive, on-drag)  | Both     | interactive                      |
 | returnKeyType                 | Boolean  | Determine if pressing 'send' will trigger handleSend                       | iOS      | false                            |
 | submitOnReturn                | Boolean  | Send message when clicking on submit                                       | Both     | false                            |
@@ -142,9 +143,9 @@ The UI is updated when receiving new ```messages``` prop.
 
 ```js
 var message = {
-  text: 'Message content', 
-  name: "Sender's name", 
-  image: {uri: 'https://facebook.github.io/react/img/logo_og.png'}, 
+  text: 'Message content',
+  name: "Sender's name",
+  image: {uri: 'https://facebook.github.io/react/img/logo_og.png'},
   position: 'left', // left if received, right if sent
   date: new Date(),
   view: null, // A custom Bubble view


### PR DESCRIPTION
The keyboardDismissMode was provided and documented, but wasn't actually used. This has now been restored/added. 

Also, I've exposed the keyboardShouldPersistsTaps prop of the ListView, so you can now choose whether or not the keyboard will be dismissed when you tap the ListView. This should resolve #80. I realise there is an underlying issue with this (keyboardShouldPersistTaps={false} + textInput focused = 2 taps are needed to trigger the ParsedText links), but IMHO it should be up to the person using GiftedMessenger to decide what weighs heavier. In my case, I really want to close the keyboard on tapping the ListView and am willing to accept the double press for opening links. 

@FaridSafi I hope you don't mind if I keep submitting some additions to your component? :)