### PR TITLE
Message: add 'undefined' check to rowData.image

### DIFF
--- a/Message.js
+++ b/Message.js
@@ -71,7 +71,7 @@ export default class Message extends React.Component {
   }
 
   renderImage(rowData, rowID, diffMessage, forceRenderImage, onImagePress){
-    if (rowData.image !== null) {
+    if (rowData.image !== undefined && rowData.image !== null) {
       if (forceRenderImage === true) {
         diffMessage = null; // force rendering
       }


### PR DESCRIPTION
sometimes we don't want to store/send redundant `rowData.image = null` if we don't need it.
add this check to prevent `Required prop 'source' was not specified in 'Image'`