### PR TITLE
Fix empty section headers warning in 0.23.0

### DIFF
--- a/GiftedMessenger.js
+++ b/GiftedMessenger.js
@@ -468,6 +468,7 @@ var GiftedMessenger = React.createClass({
           dataSource={this.state.dataSource}
           renderRow={this.renderRow}
           renderHeader={this.renderLoadEarlierMessages}
+          enableEmptySections={true}
           onLayout={(event) => {
             var layout = event.nativeEvent.layout;
             this.listHeight = layout.height;


### PR DESCRIPTION
In 0.23.0 Warning: In next release empty section headers will be rendered. In this release you can use 'enableEmptySections' flag to render empty section headers.