### PR TITLE
Replace lodash with deep-equal.

### DIFF
--- a/GiftedMessenger.js
+++ b/GiftedMessenger.js
@@ -13,7 +13,7 @@ import React, {
 import Message from './Message';
 import GiftedSpinner from 'react-native-gifted-spinner';
 import moment from 'moment';
-import _ from 'lodash';
+import deepEqual from 'deep-equal';
 import Button from 'react-native-button';
 
 class GiftedMessenger extends Component {
@@ -144,7 +144,7 @@ class GiftedMessenger extends Component {
       }
     }
 
-    if (_.isEqual(nextProps.messages, this.props.messages) === false) {
+    if (deepEqual(nextProps.messages, this.props.messages) === false) {
       let isAppended = null;
       if (nextProps.messages.length === this.props.messages.length) {
         // we assume that only a status has been changed
@@ -153,7 +153,7 @@ class GiftedMessenger extends Component {
         } else {
           isAppended = null;
         }
-      } else if (_.isEqual(nextProps.messages[nextProps.messages.length - 1], this.props.messages[this.props.messages.length - 1]) === false) {
+      } else if (deepEqual(nextProps.messages[nextProps.messages.length - 1], this.props.messages[this.props.messages.length - 1]) === false) {
         // we assume the messages were appended
         isAppended = true;
       } else {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "homepage": "https://github.com/FaridSafi/react-native-gifted-messenger#readme",
   "dependencies": {
-    "lodash": "^4.11.1",
+    "deep-equal": "^1.0.1",
     "moment": "^2.10.6",
     "react-native-button": "^1.3.1",
     "react-native-gifted-spinner": "0.0.3",


### PR DESCRIPTION
lodash is a large unnecessary dependency when only using a few small functions. Also, the current version on npm is broken because the newest version with [this fix](https://github.com/FaridSafi/react-native-gifted-messenger/commit/bda7ac8fe5bf41af5539cb200ab14e1aa7ae4918) has not been published.