### PR TITLE
Multiline TextInput + Initials avatar support

### DIFF
--- a/Message.js
+++ b/Message.js
@@ -43,11 +43,31 @@ const styles = StyleSheet.create({
     marginBottom: 10,
     marginTop: -5,
   },
+  initialContainerStyle: {
+    backgroundColor: 'rgb(1, 43, 219)',
+    borderRadius: 15,
+    width: 30,
+    height: 30,
+    paddingTop: 7,
+    marginHorizontal: 3,
+    marginTop: 2,
+  },
+  initialsStyle: {
+    color: 'white',
+    fontWeight: 'bold',
+    fontFamily: 'Helvetica',
+    fontSize: 15,
+    textAlign: 'center',
+    backgroundColor: 'transparent',
+  }
 });
 
 export default class Message extends Component {
 
   componentWillMount() {
+    Object.assign(styles, this.props.styles);
+  }
+  componentWillReceiveProps() {
     Object.assign(styles, this.props.styles);
   }
 
@@ -69,9 +89,13 @@ export default class Message extends Component {
     return null;
   }
 
-  renderImage(rowData, diffMessage, forceRenderImage, onImagePress) {
+  renderImage(rowData, diffMessage, forceRenderImage, onImagePress, useInitials=false) {
     const ImageView = rowData.imageView || Image;
-    if (rowData.image) {
+    let shouldUseInitials = useInitials && (rowData.name || rowData.initials);
+
+console.log('USE INITIALS', useInitials, shouldUseInitials, rowData)
+
+    if (rowData.image || shouldUseInitials) {
       if (forceRenderImage) {
         diffMessage = null; // force rendering
       }
@@ -83,18 +107,27 @@ export default class Message extends Component {
               underlayColor='transparent'
               onPress={() => onImagePress(rowData)}
             >
-              <ImageView
-                source={rowData.image}
-                style={[styles.imagePosition, styles.image, (rowData.position === 'left' ? styles.imageLeft : styles.imageRight)]}
-              />
+              {shouldUseInitials
+                ? <View style={styles.initialContainerStyle}>
+                    <Text style={styles.initialsStyle}>{this.getInitials(rowData)}</Text>
+                  </View>
+                : <ImageView
+                    source={rowData.image}
+                    style={[styles.imagePosition, styles.image, (rowData.position === 'left' ? styles.imageLeft : styles.imageRight)]}
+                  />
+              }
             </TouchableHighlight>
           );
         }
         return (
-          <ImageView
-            source={rowData.image}
-            style={[styles.imagePosition, styles.image, (rowData.position === 'left' ? styles.imageLeft : styles.imageRight)]}
-          />
+          shouldUseInitials
+            ? <View style={styles.initialContainerStyle}>
+                <Text style={styles.initialsStyle}>{this.getInitials(rowData)}</Text>
+              </View>
+            : <ImageView
+                source={rowData.image}
+                style={[styles.imagePosition, styles.image, (rowData.position === 'left' ? styles.imageLeft : styles.imageRight)]}
+              />
         );
       }
       return (
@@ -104,6 +137,18 @@ export default class Message extends Component {
     return (
       <View style={styles.spacer} />
     );
+  }
+
+  getInitials({initials, name}) {
+    if(initials) return initials;
+    else if(name) {
+      let parts = name.split(' ');
+      let first = parts[0];
+      let last = parts[parts.length-1];
+      initials = first[0] + (last !== first ? last[0] : '');
+      return initials.toUpperCase();
+    }
+    else return '?';
   }
 
   renderErrorButton(rowData, onErrorButtonPress) {
@@ -142,6 +187,7 @@ export default class Message extends Component {
       forceRenderImage,
       onImagePress,
       onMessageLongPress,
+      useInitials,
     } = this.props;
 
     const flexStyle = {};
@@ -177,7 +223,7 @@ export default class Message extends Component {
             handleUrlPress={this.props.handleUrlPress}
             handleEmailPress={this.props.handleEmailPress}
           />
-          {rowData.position === 'right' ? this.renderImage(rowData, diffMessage, forceRenderImage, onImagePress) : null}
+          {rowData.position === 'right' ? this.renderImage(rowData, diffMessage, forceRenderImage, onImagePress, useInitials) : null}
         </View>
         {rowData.position === 'right' ? this.renderStatus(rowData.status) : null}
       </View>

--- a/README.md
+++ b/README.md
@@ -81,7 +81,12 @@ See [GiftedMessengerExample/GiftedMessengerContainer.js](https://raw.githubuserc
 | senderName                    | String   | Name of the sender of the messages                                         | Both     | 'Sender'                         |
 | styles                        | Function | Styles of children components - See GiftedMessenger.js/componentWillMount  | Both     | {}                               |
 | submitOnReturn                | Boolean  | Send message when clicking on submit                                       | Both     | false                            |
-| typingMessage                 | String   | Display a text at the bottom of the list. Eg: 'User is typing a message'   | Both     | ''                               |
+| typingMessage                 | String   | Display a text at the bottom of the list. Eg: 'User is typing a message'   | Both     | ''    
+| textInputProps                | Object   | Props passed to Textinput                                                  | Both     | {}  
+| multiline                     | Boolean  | When true, textinput expands vertically on return                          | Both     | false  
+| maxInputHeight                | Number   | Maximum height the textinput can grow to                                   | Both     | 250  
+| onTextInputHeightChanged      | Function | Called when textinput grows. **Params:** *newHeight, oldHeight, delta*     | Both     | null  
+| useInitials                   | Boolean  | When true, `name` or `initials` prop of `rowData` used to generate initials| Both     | false  
 
 
 ### Message object

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-gifted-messenger",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Chat UI for iOS and Android React-Native apps",
   "main": "GiftedMessenger.js",
   "scripts": {
@@ -33,7 +33,8 @@
     "moment": "^2.10.6",
     "react-native-button": "^1.3.1",
     "react-native-gifted-spinner": "0.0.3",
-    "react-native-parsed-text": "0.0.11"
+    "react-native-parsed-text": "0.0.11",
+    "react-native-autogrow-textinput": "github:faceyspacey/react-native-autogrow-textinput"
   },
   "devDependencies": {
     "eslint": "^2.7.0",


### PR DESCRIPTION
To enable multiline textinputs, set `multiline` to true as a property to `GiftedMessenger` to enable. set `maxInputHeight` to specify the maximum height the input can grow too. If you need the change event for when it changes height, use `onTextInputHeightChanged`. You can pass additional props to the input now with `textInputProps`. 

IMPLEMENTATION NOTES:
The autogrowing part was easy. What was very time-consuming was getting the positioning compensation for the ListView so the correct part was always placed properly (similar to the iPhone text message app). I had to animate the textinput separately (well, its container). So similar to the ListView container, I animate its height. They are both done in parallel, but could likely be optimized to interpolate. The reason it had to be done separately--and believe me, I tried to use the initial mechanism to move the input up--is because when the placement of the textinput is dependent on the height of the ListView, then you can't move the ListView (in relation to the TextInput) without also moving the TextInput. I spent a long time trying to do that via various ways and things just got tangled, so I did what I probably should have originally did which was isolate the TextInput so it moves in an unrelated fashion. Absolute positioning and a `bottom` property are used to have the textinput stick to the bottom and grow up from the bottom. Aside from the listview placement compensation, the bottom-based absolute positioning is its secret sauce.
