### PR TITLE
renderCustomText render if not return false value  and fix two-byte characters length error

### DIFF
--- a/Bubble.js
+++ b/Bubble.js
@@ -96,8 +96,11 @@ export default class Bubble extends React.Component {
 
   render() {
     const flexStyle = {};
+    const realLength = function(str) {
+      return str.replace(/[^\x00-\xff]/g, "**").length; // [^\x00-\xff] - Matching non double byte character
+    };
     if (this.props.text) {
-      if (this.props.text.length > 40) {
+      if (realLength(this.props.text) > 40) {
         flexStyle.flex = 1;
       }
     }

--- a/Bubble.js
+++ b/Bubble.js
@@ -48,7 +48,7 @@ export default class Bubble extends React.Component {
   }
 
   renderText(text = '', position) {
-    if (this.props.renderCustomText) {
+    if (this.props.renderCustomText && this.props.renderCustomText(this.props) !==false) {
       return this.props.renderCustomText(this.props);
     }
 


### PR DESCRIPTION
in this issues:https://github.com/FaridSafi/react-native-gifted-messenger/issues/124,i want to render my custom text.then now i can use:
rederCustomText(rowData){
if(rowData.type=='image'){
....reder CustomText
} else {
   return false;
}
}