### PR TITLE
changed renderCustomText to only be used once

### DIFF
--- a/Bubble.js
+++ b/Bubble.js
@@ -48,8 +48,11 @@ export default class Bubble extends React.Component {
   }
 
   renderText(text = '', position) {
-    if (this.props.renderCustomText && this.props.renderCustomText(this.props) !==false) {
-      return this.props.renderCustomText(this.props);
+    if (this.props.renderCustomText) {
+      const customRenderedText = this.props.renderCustomText(this.props);
+      if (customRenderedText !== false) {
+        return customRenderedText;
+      }
     }
 
     if (this.props.parseText === true) {


### PR DESCRIPTION
- The function was used twice in Bubble RenderText when it was present, which is not really efficient, especially if the function instantiates a few components.