### PR TITLE
fix(style): perform a deep merge of styles

### DIFF
--- a/GiftedMessenger.js
+++ b/GiftedMessenger.js
@@ -18,6 +18,7 @@ import moment from 'moment';
 import {setLocale} from './Locale';
 import deepEqual from 'deep-equal';
 import Button from 'react-native-button';
+import * as _ from 'lodash';
 
 class GiftedMessenger extends Component {
 
@@ -129,7 +130,7 @@ class GiftedMessenger extends Component {
       },
     };
 
-    Object.assign(this.styles, this.props.styles);
+    _.merge(this.styles, this.props.styles);
 
     if (this.props.dateLocale !== '')
       setLocale(this.props.dateLocale);

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/FaridSafi/react-native-gifted-messenger#readme",
   "dependencies": {
     "deep-equal": "^1.0.1",
+    "lodash": "^4.13.1",
     "moment": "^2.10.6",
     "react-native-button": "^1.5.0",
     "react-native-gifted-spinner": "^0.0.4",


### PR DESCRIPTION
To enable being able to override just some of the properties of the styling, perform a deep merge with lodash instead of Object.assign, as Object.assign only does a shallow merge.