### PR TITLE
Fix dispatchViewManagerCommand error when calling scrollToBottom()

### DIFF
--- a/GiftedMessenger.js
+++ b/GiftedMessenger.js
@@ -37,6 +37,7 @@ class GiftedMessenger extends Component {
     this.onChangeText = this.onChangeText.bind(this);
     this.onSend = this.onSend.bind(this);
 
+    this._isMounted = false;
     this._firstDisplay = true;
     this._listHeight = 0;
     this._footerY = 0;
@@ -136,6 +137,8 @@ class GiftedMessenger extends Component {
   }
 
   componentDidMount() {
+    this._isMounted = true;
+
     this.scrollResponder = this.refs.listView.getScrollResponder();
 
     if (this.props.messages.length > 0) {
@@ -195,6 +198,10 @@ class GiftedMessenger extends Component {
         height: new Animated.Value(this.listViewMaxHeight),
       });
     }
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
   }
 
   onSend() {
@@ -372,7 +379,7 @@ class GiftedMessenger extends Component {
   }
 
   scrollToBottom(animated = null) {
-    if (this._listHeight && this._footerY && this._footerY > this._listHeight) {
+    if (this._isMounted && this._listHeight && this._footerY && this._footerY > this._listHeight) {
       let scrollDistance = this._listHeight - this._footerY;
       if (this.props.typingMessage) {
         scrollDistance -= 44;


### PR DESCRIPTION
The Error: `Argument 0 (NSNumber) of RCTUIManager.dispatchViewManagerCommand must not be null`

Let's say there are two screens - 1) `GiftMessengerScreen` 2) `KeyboardWillShowScreen`.
This error happens when I navigate from `GiftMessengerScreen` to `KeyboardWillShowScreen`, because the `scollToBottom()` function is still calling in the `onKeyboardDidShow` event.

similar to this issue: https://github.com/aksonov/react-native-router-flux/issues/762#issuecomment-222540708

Fix: only allow scollToBottom() when the component is mounted.


